### PR TITLE
Correction of some causes of crashing

### DIFF
--- a/notebooks/DataModeling_PARADIM.ipynb
+++ b/notebooks/DataModeling_PARADIM.ipynb
@@ -64,6 +64,8 @@
     "            'name of vaseline',\n",
     "            bounds=CategoricalBounds(['Vaspure','Vaseline','Giant','Nivea'])\n",
     "        ),\n",
+    "    ],\n",
+    "    conditions=[
     "        ConditionTemplate(\n",
     "            'humidity',\n",
     "            bounds=RealBounds(0.,1.0,'dimensionless')\n",
@@ -90,7 +92,7 @@
     "    parameters=[\n",
     "        Parameter(\n",
     "            'mass of sample',\n",
-    "            value=NominalReal(float(creating_puck['amount of smaple']),'g'),\n",
+    "            value=NominalReal(float(creating_puck['mass of sample']),'g'),\n",
     "        ),\n",
     "        Parameter(\n",
     "            'glass thickness',\n",
@@ -401,8 +403,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_ET = make_instance(spec_TT)\n",
-    "run_ET.source = PerformedSource(PPMS_TT_setup['name'],PPMS_TT_setup['date'])"
+    "run_TT = make_instance(spec_TT)\n",
+    "run_TT.source = PerformedSource(PPMS_TT_setup['name'],PPMS_TT_setup['date'])"
    ]
   },
   {


### PR DESCRIPTION
Fixed a variable name, corrected one of the first blocks crashing, changed "run_ET" to "run_TT" in the TT segment. May not be formatted correctly, since it's hard to tell 100% for me in .ipynb format.